### PR TITLE
Adding requestId tracing in the cli plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-    "extends": "@adobe/eslint-config-aio-lib-config",
     "settings": {
         "jsdoc": {
           "ignorePrivate": true
@@ -8,5 +7,25 @@
     "parser": "@babel/eslint-parser",
     "parserOptions": {
         "requireConfigFile": false
-    }
+    },
+    "extends": [
+        "eslint:recommended",
+		"plugin:@typescript-eslint/recommended",
+		"plugin:@typescript-eslint/eslint-recommended",
+		"plugin:prettier/recommended"
+    ],
+    "plugins": ["@typescript-eslint/eslint-plugin", "prettier"],
+	"rules": {
+        "no-unused-vars": "warn",
+		"prettier/prettier": "warn"
+	},
+    "overrides": [
+		{
+			"files": ["*.js"],
+			"rules": {
+				"@typescript-eslint/no-var-requires": "off",
+                "no-undef": "off"
+			}
+		}
+	]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# dependencies
+.npm
+node_modules
+
+# build
+.cache
+dist
+storybook
+
+# test
+coverage
+
+# misc
+.env
+CHANGELOG.md
+*.yaml

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -9,20 +9,22 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const execa = require('execa')
-const chalk = require('chalk')
-const { stdout } = require('stdout-stderr')
-const fs = require('fs')
+const execa = require('execa');
+const chalk = require('chalk');
+const { stdout } = require('stdout-stderr');
+const fs = require('fs');
 
-stdout.print = true
+stdout.print = true;
 
 test('boilerplate help test', async () => {
-  const packagejson = JSON.parse(fs.readFileSync('package.json').toString())
-  const name = `${packagejson.name}`
-  console.log(chalk.blue(`> e2e tests for ${chalk.bold(name)}`))
+	const packagejson = JSON.parse(fs.readFileSync('package.json').toString());
+	const name = `${packagejson.name}`;
+	console.log(chalk.blue(`> e2e tests for ${chalk.bold(name)}`));
 
-  console.log(chalk.dim('    - boilerplate help ..'))
-  expect(() => { execa.sync('./bin/run', ['--help'], { stderr: 'inherit' }) }).not.toThrow()
+	console.log(chalk.dim('    - boilerplate help ..'));
+	expect(() => {
+		execa.sync('./bin/run', ['--help'], { stderr: 'inherit' });
+	}).not.toThrow();
 
-  console.log(chalk.green(`    - done for ${chalk.bold(name)}`))
-})
+	console.log(chalk.green(`    - done for ${chalk.bold(name)}`));
+});

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -13,18 +13,19 @@ const execa = require('execa');
 const chalk = require('chalk');
 const { stdout } = require('stdout-stderr');
 const fs = require('fs');
+const logger = require('../src/classes/logger');
 
 stdout.print = true;
 
 test('boilerplate help test', async () => {
 	const packagejson = JSON.parse(fs.readFileSync('package.json').toString());
 	const name = `${packagejson.name}`;
-	console.log(chalk.blue(`> e2e tests for ${chalk.bold(name)}`));
+	logger.info(chalk.blue(`> e2e tests for ${chalk.bold(name)}`));
 
-	console.log(chalk.dim('    - boilerplate help ..'));
+	logger.info(chalk.dim('    - boilerplate help ..'));
 	expect(() => {
 		execa.sync('./bin/run', ['--help'], { stderr: 'inherit' });
 	}).not.toThrow();
 
-	console.log(chalk.green(`    - done for ${chalk.bold(name)}`));
+	logger.info(chalk.green(`    - done for ${chalk.bold(name)}`));
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,10 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { stdout, stderr } = require('stdout-stderr')
+const { stdout, stderr } = require('stdout-stderr');
 
-jest.setTimeout(30000)
+jest.setTimeout(30000);
 
 // trap console log
-beforeEach(() => { stdout.start(); stderr.start() })
-afterEach(() => { stdout.stop(); stderr.stop() })
+beforeEach(() => {
+	stdout.start();
+	stderr.start();
+});
+afterEach(() => {
+	stdout.stop();
+	stderr.stop();
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "pino": "^7.9.2",
     "pino-pretty": "^7.6.0",
-    "request-context": "^2.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,22 @@
     "access": "public"
   },
   "dependencies": {
+    "@adobe/aio-cli-lib-console": "^3.0.0",
     "@adobe/aio-lib-core-config": "^2.0.0",
     "@adobe/aio-lib-core-logging": "^1.1.0",
     "@adobe/aio-lib-env": "^1.1.0",
     "@adobe/aio-lib-ims": "^5.0.1",
-    "@adobe/aio-cli-lib-console": "^3.0.0",
     "@oclif/command": "^1.6.1",
     "@oclif/config": "^1.15.1",
     "@oclif/errors": "^1.1.2",
-    "axios": "^0.23.0"
+    "@typescript-eslint/eslint-plugin": "^5.18.0",
+    "axios": "^0.23.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "pino": "^7.9.2",
+    "pino-pretty": "^7.6.0",
+    "request-context": "^2.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "^1.4.0",
@@ -65,7 +72,9 @@
     "prepack": "oclif-dev manifest && oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif-dev readme && git add README.md",
-    "e2e": "jest --collectCoverage=false --testRegex './e2e/e2e.js'"
+    "e2e": "jest --collectCoverage=false --testRegex './e2e/e2e.js'",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix ."
   },
   "jest": {
     "collectCoverage": true,

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,17 @@
+const config = {
+	printWidth: 100,
+	tabWidth: 2,
+	useTabs: true,
+	singleQuote: true,
+	quoteProps: 'consistent',
+	trailingComma: 'all',
+	arrowParens: 'avoid',
+	endOfLine: 'lf',
+
+	// config options to be passed to prettier-plugin-sort-imports
+	importOrder: ['^@core/(.*)$', '^@server/(.*)$', '^@ui/(.*)$', '^[./]'],
+	importOrderSeparation: true,
+	importOrderSortSpecifiers: true,
+};
+
+module.exports = config;

--- a/src/classes/SchemaServiceClient.js
+++ b/src/classes/SchemaServiceClient.js
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 
 const axios = require('axios');
 const logger = require('../classes/logger');
-const { getRequestId } = require('../helpers');
 
 /**
  * This class provides methods to call Schema Management Service APIs.
@@ -32,7 +31,7 @@ class SchemaServiceClient {
 			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
-				'x-request-id': getRequestId(),
+				'x-request-id': global.requestId,
 			},
 		};
 		try {
@@ -53,7 +52,7 @@ class SchemaServiceClient {
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',
-				'x-request-id': getRequestId(),
+				'x-request-id': global.requestId,
 			},
 			data: JSON.stringify(data),
 		};
@@ -75,7 +74,7 @@ class SchemaServiceClient {
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',
-				'x-request-id': getRequestId(),
+				'x-request-id': global.requestId,
 			},
 			data: JSON.stringify(data),
 		};

--- a/src/classes/SchemaServiceClient.js
+++ b/src/classes/SchemaServiceClient.js
@@ -9,7 +9,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const axios = require('axios')
+const axios = require('axios');
+const logger = require('pino');
+const requestContext = require('request-context');
 
 /**
  * This class provides methods to call Schema Management Service APIs.
@@ -17,78 +19,72 @@ const axios = require('axios')
  * with valid values for baseUrl, apiKey and accessToken
  */
 class SchemaServiceClient {
-  init (baseUrl, accessToken, apiKey) {
-    this.schemaManagementServiceUrl = baseUrl
-    this.accessToken = accessToken
-    this.apiKey = apiKey
-  }
+	init(baseUrl, accessToken, apiKey) {
+		this.schemaManagementServiceUrl = baseUrl;
+		this.accessToken = accessToken;
+		this.apiKey = apiKey;
+	}
 
-  async getTenant (tenantId, organizationCode) {
-    console.log(`OrgCode - getTenant: ${organizationCode}`)
-    const config = {
-      method: 'get',
-      url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`
-      }
-    }
-    try {
-      const response = await axios(config)
-      console.log(`Config : ${config}`)
-      return response && response.data &&
-      response.status === 200
-        ? response.data
-        : null
-    } catch (error) {
-      throw new Error(JSON.stringify(error.response.data))
-    }
-  }
+	async getTenant(tenantId, organizationCode) {
+		logger.info(`OrgCode - getTenant: ${organizationCode}`);
+		const config = {
+			method: 'get',
+			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
+			headers: {
+				'Authorization': `Bearer ${this.accessToken}`,
+				'x-request-id': requestContext.get('requestId'),
+			},
+		};
+		try {
+			const response = await axios(config);
+			logger.info(`Config : ${config}`);
+			return response && response.data && response.status === 200 ? response.data : null;
+		} catch (error) {
+			throw new Error(JSON.stringify(error.response.data));
+		}
+	}
 
-  async createTenant (data) {
-    const organizationCode = data.imsOrgId
-    console.log(`OrgCode - createTenant: ${organizationCode}`)
-    const config = {
-      method: 'post',
-      url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants?api_key=${this.apiKey}`,
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-        'Content-Type': 'application/json'
-      },
-      data: JSON.stringify(data)
-    }
-    try {
-      console.log('here')
-      const response = await axios(config)
-      return response && response.status === 201
-        ? response
-        : null
-    } catch (error) {
-      throw new Error(JSON.stringify(error.response.data))
-    }
-  }
+	async createTenant(data) {
+		const organizationCode = data.imsOrgId;
+		console.log(`OrgCode - createTenant: ${organizationCode}`);
+		const config = {
+			method: 'post',
+			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants?api_key=${this.apiKey}`,
+			headers: {
+				'Authorization': `Bearer ${this.accessToken}`,
+				'Content-Type': 'application/json',
+			},
+			data: JSON.stringify(data),
+		};
+		try {
+			console.log('here');
+			const response = await axios(config);
+			return response && response.status === 201 ? response : null;
+		} catch (error) {
+			throw new Error(JSON.stringify(error.response.data));
+		}
+	}
 
-  async updateTenant (tenantId, data) {
-    const organizationCode = data.imsOrgId
-    console.log(`OrgCode - updateTenant: ${organizationCode}`)
-    const config = {
-      method: 'put',
-      url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-        'Content-Type': 'application/json'
-      },
-      data: JSON.stringify(data)
-    }
-    try {
-      const response = await axios(config)
-      console.log(response.status)
-      return response && response.status === 204
-        ? response
-        : null
-    } catch (error) {
-      throw new Error(JSON.stringify(error.response.data))
-    }
-  }
+	async updateTenant(tenantId, data) {
+		const organizationCode = data.imsOrgId;
+		console.log(`OrgCode - updateTenant: ${organizationCode}`);
+		const config = {
+			method: 'put',
+			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
+			headers: {
+				'Authorization': `Bearer ${this.accessToken}`,
+				'Content-Type': 'application/json',
+			},
+			data: JSON.stringify(data),
+		};
+		try {
+			const response = await axios(config);
+			console.log(response.status);
+			return response && response.status === 204 ? response : null;
+		} catch (error) {
+			throw new Error(JSON.stringify(error.response.data));
+		}
+	}
 }
 
-module.exports = { SchemaServiceClient }
+module.exports = { SchemaServiceClient };

--- a/src/classes/SchemaServiceClient.js
+++ b/src/classes/SchemaServiceClient.js
@@ -39,6 +39,7 @@ class SchemaServiceClient {
 			logger.info(`Config : ${config}`);
 			return response && response.data && response.status === 200 ? response.data : null;
 		} catch (error) {
+			logger.error(error);
 			throw new Error(JSON.stringify(error.response.data));
 		}
 	}
@@ -61,6 +62,7 @@ class SchemaServiceClient {
 			const response = await axios(config);
 			return response && response.status === 201 ? response : null;
 		} catch (error) {
+			logger.error(error);
 			throw new Error(JSON.stringify(error.response.data));
 		}
 	}
@@ -83,6 +85,7 @@ class SchemaServiceClient {
 			logger.info(response.status);
 			return response && response.status === 204 ? response : null;
 		} catch (error) {
+			logger.error(error);
 			throw new Error(JSON.stringify(error.response.data));
 		}
 	}

--- a/src/classes/SchemaServiceClient.js
+++ b/src/classes/SchemaServiceClient.js
@@ -10,8 +10,8 @@ governing permissions and limitations under the License.
 */
 
 const axios = require('axios');
-const logger = require('pino');
-const requestContext = require('request-context');
+const logger = require('../classes/logger');
+const { UUID } = require('./UUID');
 
 /**
  * This class provides methods to call Schema Management Service APIs.
@@ -23,6 +23,7 @@ class SchemaServiceClient {
 		this.schemaManagementServiceUrl = baseUrl;
 		this.accessToken = accessToken;
 		this.apiKey = apiKey;
+		this.requestId = UUID.newUuid().toString();
 	}
 
 	async getTenant(tenantId, organizationCode) {
@@ -32,7 +33,7 @@ class SchemaServiceClient {
 			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
-				'x-request-id': requestContext.get('requestId'),
+				'x-request-id': this.requestId,
 			},
 		};
 		try {
@@ -46,18 +47,19 @@ class SchemaServiceClient {
 
 	async createTenant(data) {
 		const organizationCode = data.imsOrgId;
-		console.log(`OrgCode - createTenant: ${organizationCode}`);
+		logger.info(`OrgCode - createTenant: ${organizationCode}`);
 		const config = {
 			method: 'post',
 			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants?api_key=${this.apiKey}`,
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',
+				'x-request-id': this.requestId,
 			},
 			data: JSON.stringify(data),
 		};
 		try {
-			console.log('here');
+			logger.info('here');
 			const response = await axios(config);
 			return response && response.status === 201 ? response : null;
 		} catch (error) {
@@ -67,19 +69,20 @@ class SchemaServiceClient {
 
 	async updateTenant(tenantId, data) {
 		const organizationCode = data.imsOrgId;
-		console.log(`OrgCode - updateTenant: ${organizationCode}`);
+		logger.info(`OrgCode - updateTenant: ${organizationCode}`);
 		const config = {
 			method: 'put',
 			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',
+				'x-request-id': this.requestId,
 			},
 			data: JSON.stringify(data),
 		};
 		try {
 			const response = await axios(config);
-			console.log(response.status);
+			logger.info(response.status);
 			return response && response.status === 204 ? response : null;
 		} catch (error) {
 			throw new Error(JSON.stringify(error.response.data));

--- a/src/classes/SchemaServiceClient.js
+++ b/src/classes/SchemaServiceClient.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 const axios = require('axios');
 const logger = require('../classes/logger');
-const { UUID } = require('./UUID');
+const { getRequestId } = require('../helpers');
 
 /**
  * This class provides methods to call Schema Management Service APIs.
@@ -23,7 +23,6 @@ class SchemaServiceClient {
 		this.schemaManagementServiceUrl = baseUrl;
 		this.accessToken = accessToken;
 		this.apiKey = apiKey;
-		this.requestId = UUID.newUuid().toString();
 	}
 
 	async getTenant(tenantId, organizationCode) {
@@ -33,7 +32,7 @@ class SchemaServiceClient {
 			url: `${this.schemaManagementServiceUrl}/api-admin/organizations/${organizationCode}/tenants/${tenantId}?api_key=${this.apiKey}`,
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
-				'x-request-id': this.requestId,
+				'x-request-id': getRequestId(),
 			},
 		};
 		try {
@@ -54,7 +53,7 @@ class SchemaServiceClient {
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',
-				'x-request-id': this.requestId,
+				'x-request-id': getRequestId(),
 			},
 			data: JSON.stringify(data),
 		};
@@ -76,7 +75,7 @@ class SchemaServiceClient {
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',
-				'x-request-id': this.requestId,
+				'x-request-id': getRequestId(),
 			},
 			data: JSON.stringify(data),
 		};

--- a/src/classes/UUID.js
+++ b/src/classes/UUID.js
@@ -1,0 +1,20 @@
+const { v4: uuidv4 } = require('uuid');
+//Class representing a new unique UUID which is used for request-id tracing
+class UUID {
+	constructor(uuid = '') {
+		this.uuid = uuid;
+	}
+
+	toString() {
+		return this.uuid;
+	}
+
+	static newUuid() {
+		const newUUID = uuidv4();
+		return new UUID(newUUID);
+	}
+}
+
+module.exports = {
+	UUID,
+};

--- a/src/classes/logger.js
+++ b/src/classes/logger.js
@@ -17,3 +17,5 @@ const logger = pino({
 		},
 	},
 });
+
+module.exports = logger;

--- a/src/classes/logger.js
+++ b/src/classes/logger.js
@@ -1,5 +1,4 @@
 const { default: pino } = require('pino');
-const requestContext = require('request-context');
 
 const logger = pino({
 	level: process.env.LOG_LEVEL || 'info',
@@ -7,7 +6,7 @@ const logger = pino({
 	prettyPrint: !process.env.ENVIRONMENT_NAME,
 	mixin() {
 		return {
-			requestId: requestContext.get('requestId'),
+			requestId: global.requestId
 		};
 	},
 	transport: {

--- a/src/classes/logger.js
+++ b/src/classes/logger.js
@@ -3,10 +3,9 @@ const { default: pino } = require('pino');
 const logger = pino({
 	level: process.env.LOG_LEVEL || 'info',
 	enabled: process.env.NODE_ENV !== 'test',
-	prettyPrint: !process.env.ENVIRONMENT_NAME,
 	mixin() {
 		return {
-			requestId: global.requestId
+			requestId: global.requestId,
 		};
 	},
 	transport: {

--- a/src/classes/logger.js
+++ b/src/classes/logger.js
@@ -1,0 +1,19 @@
+const { default: pino } = require('pino');
+const requestContext = require('request-context');
+
+const logger = pino({
+	level: process.env.LOG_LEVEL || 'info',
+	enabled: process.env.NODE_ENV !== 'test',
+	prettyPrint: !process.env.ENVIRONMENT_NAME,
+	mixin() {
+		return {
+			requestId: requestContext.get('requestId'),
+		};
+	},
+	transport: {
+		target: 'pino-pretty',
+		options: {
+			colorize: true,
+		},
+	},
+});

--- a/src/commands/PLUGINNAME/index.js
+++ b/src/commands/PLUGINNAME/index.js
@@ -10,25 +10,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { Command, flags } = require('@oclif/command')
-const aioLogger = require('@adobe/aio-lib-core-logging')('PLUGINNAME', { provider: 'debug' })
+const { Command, flags } = require('@oclif/command');
+const aioLogger = require('@adobe/aio-lib-core-logging')('PLUGINNAME', { provider: 'debug' });
 
 class IndexCommand extends Command {
-  async run () {
-    // const { args, flags } = this.parse(IndexCommand)
-    aioLogger.debug('this is the index command.')
-  }
+	async run() {
+		// const { args, flags } = this.parse(IndexCommand)
+		aioLogger.debug('this is the index command.');
+	}
 }
 
 IndexCommand.flags = {
-  someflag: flags.string({ char: 'f', description: 'this is some flag' })
-}
+	someflag: flags.string({ char: 'f', description: 'this is some flag' }),
+};
 
 // this is set in package.json, see https://github.com/oclif/oclif/issues/120
 // if not set it will get the first (alphabetical) topic's help description
-IndexCommand.description = 'Your description here'
-IndexCommand.examples = [
-  '$ aio PLUGINNAME:some_command'
-]
+IndexCommand.description = 'Your description here';
+IndexCommand.examples = ['$ aio PLUGINNAME:some_command'];
 
-module.exports = IndexCommand
+module.exports = IndexCommand;

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command');
 const { readFile } = require('fs/promises');
-const { initSdk } = require('../../../helpers');
+const { initSdk, initRequestId } = require('../../../helpers');
 const logger = require('../../../classes/logger');
 
 class CreateCommand extends Command {
@@ -21,6 +21,8 @@ class CreateCommand extends Command {
 		logger.info('Start create tenant');
 		const { args } = this.parse(CreateCommand);
 		const { schemaServiceClient, imsOrgCode } = await initSdk();
+		await initRequestId();
+		logger.info(`RequestId: ${global.requestId}`);
 		
 		let data;
 		try {

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -18,12 +18,11 @@ class CreateCommand extends Command {
 	static args = [{ name: 'file' }];
 
 	async run() {
+		await initRequestId();
+		logger.info(`RequestId: ${global.requestId}`);
 		logger.info('Start create tenant');
 		const { args } = this.parse(CreateCommand);
 		const { schemaServiceClient, imsOrgCode } = await initSdk();
-		await initRequestId();
-		logger.info(`RequestId: ${global.requestId}`);
-		
 		let data;
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -9,34 +9,41 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { Command } = require('@oclif/command')
-const { readFile } = require('fs/promises')
-const { initSdk } = require('../../../helpers')
+const { Command } = require('@oclif/command');
+const { readFile } = require('fs/promises');
+const { UUID } = require('../../../classes/UUID');
+const { initSdk } = require('../../../helpers');
+const logger = require('pino');
+const requestContext = require('request-context');
 
 class CreateCommand extends Command {
-  static args = [
-    { name: 'file' }
-  ]
+	static args = [{ name: 'file' }];
 
-  async run () {
-    console.log('Start create tenant')
-    const { args } = this.parse(CreateCommand)
-    const { schemaServiceClient, imsOrgCode } = await initSdk()
-    let data
-    try {
-      data = JSON.parse(await readFile(args.file, 'utf8'))
-    } catch (error) {
-      this.error('Unable to create a tenant with the given configuration')
-    }
-    data.imsOrgId = imsOrgCode
-    const tenant = await schemaServiceClient.createTenant(data)
-    tenant
-      ? this.log(`Successfully created a tenant with the ID: ${data.tenantId} and imsOrgCode: ${data.imsOrgId}`)
-      : this.error(`Unable to create a tenant with the ID ${data.tenantId}`)
-    return tenant
-  }
+	async run() {
+		logger.info('Start create tenant');
+		const { args } = this.parse(CreateCommand);
+		const { schemaServiceClient, imsOrgCode } = await initSdk();
+		//let's generate a requestid
+		const requestId = UUID.newUuid();
+		requestContext.set('requestId', requestId);
+		let data;
+		try {
+			data = JSON.parse(await readFile(args.file, 'utf8'));
+		} catch (error) {
+			logger.error('Unable to create a tenant with the given configuration');
+			this.error('Unable to create a tenant with the given configuration');
+		}
+		data.imsOrgId = imsOrgCode;
+		const tenant = await schemaServiceClient.createTenant(data);
+		tenant
+			? this.log(
+					`Successfully created a tenant with the ID: ${data.tenantId} and imsOrgCode: ${data.imsOrgId}`,
+			  )
+			: this.error(`Unable to create a tenant with the ID ${data.tenantId}`);
+		return tenant;
+	}
 }
 
-CreateCommand.description = 'Create a tenant with the given config.'
+CreateCommand.description = 'Create a tenant with the given config.';
 
-module.exports = CreateCommand
+module.exports = CreateCommand;

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -27,7 +27,7 @@ class CreateCommand extends Command {
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 		} catch (error) {
-			logger.error('Unable to create a tenant with the given configuration');
+			logger.error(error);
 			this.error('Unable to create a tenant with the given configuration');
 		}
 		data.imsOrgId = imsOrgCode;

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -11,10 +11,8 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command');
 const { readFile } = require('fs/promises');
-const { UUID } = require('../../../classes/UUID');
 const { initSdk } = require('../../../helpers');
-const logger = require('pino');
-const requestContext = require('request-context');
+const logger = require('../../../classes/logger');
 
 class CreateCommand extends Command {
 	static args = [{ name: 'file' }];
@@ -23,9 +21,7 @@ class CreateCommand extends Command {
 		logger.info('Start create tenant');
 		const { args } = this.parse(CreateCommand);
 		const { schemaServiceClient, imsOrgCode } = await initSdk();
-		//let's generate a requestid
-		const requestId = UUID.newUuid();
-		requestContext.set('requestId', requestId);
+		
 		let data;
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));

--- a/src/commands/commerce-gateway/tenant/get.js
+++ b/src/commands/commerce-gateway/tenant/get.js
@@ -10,12 +10,15 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command');
-const { initSdk } = require('../../../helpers');
+const logger = require('../../../classes/logger');
+const { initSdk, initRequestId } = require('../../../helpers');
 
 class GetCommand extends Command {
 	static args = [{ name: 'tenantId' }];
 
 	async run() {
+		await initRequestId();
+		logger.info(`RequestId: ${global.requestId}`);
 		const { args } = this.parse(GetCommand);
 		const { schemaServiceClient, imsOrgCode } = await initSdk();
 		const tenant = await schemaServiceClient.getTenant(args.tenantId, imsOrgCode);

--- a/src/commands/commerce-gateway/tenant/get.js
+++ b/src/commands/commerce-gateway/tenant/get.js
@@ -9,25 +9,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { Command } = require('@oclif/command')
-const { initSdk } = require('../../../helpers')
+const { Command } = require('@oclif/command');
+const { initSdk } = require('../../../helpers');
 
 class GetCommand extends Command {
-  static args = [
-    { name: 'tenantId' }
-  ]
+	static args = [{ name: 'tenantId' }];
 
-  async run () {
-    const { args } = this.parse(GetCommand)
-    const { schemaServiceClient, imsOrgCode } = await initSdk()
-    const tenant = await schemaServiceClient.getTenant(args.tenantId, imsOrgCode)
-    tenant
-      ? this.log(JSON.stringify(tenant))
-      : this.error(`Unable to retrieve the tenant config for ${args.tenantId}`)
-    return tenant
-  }
+	async run() {
+		const { args } = this.parse(GetCommand);
+		const { schemaServiceClient, imsOrgCode } = await initSdk();
+		const tenant = await schemaServiceClient.getTenant(args.tenantId, imsOrgCode);
+		tenant
+			? this.log(JSON.stringify(tenant))
+			: this.error(`Unable to retrieve the tenant config for ${args.tenantId}`);
+		return tenant;
+	}
 }
 
-GetCommand.description = 'Get the config of a given tenant'
+GetCommand.description = 'Get the config of a given tenant';
 
-module.exports = GetCommand
+module.exports = GetCommand;

--- a/src/commands/commerce-gateway/tenant/update.js
+++ b/src/commands/commerce-gateway/tenant/update.js
@@ -26,6 +26,7 @@ class UpdateCommand extends Command {
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 		} catch (error) {
+			logger.error(error);
 			this.error('Unable to update the tenant with the given configuration');
 		}
 		data.imsOrgId = imsOrgCode;

--- a/src/commands/commerce-gateway/tenant/update.js
+++ b/src/commands/commerce-gateway/tenant/update.js
@@ -9,34 +9,31 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { Command } = require('@oclif/command')
-const { readFile } = require('fs/promises')
-const { initSdk } = require('../../../helpers')
+const { Command } = require('@oclif/command');
+const { readFile } = require('fs/promises');
+const { initSdk } = require('../../../helpers');
 
 class UpdateCommand extends Command {
-  static args = [
-    { name: 'tenantId' },
-    { name: 'file' }
-  ]
+	static args = [{ name: 'tenantId' }, { name: 'file' }];
 
-  async run () {
-    const { args } = this.parse(UpdateCommand)
-    const { schemaServiceClient, imsOrgCode } = await initSdk()
-    let data
-    try {
-      data = JSON.parse(await readFile(args.file, 'utf8'))
-    } catch (error) {
-      this.error('Unable to update the tenant with the given configuration')
-    }
-    data.imsOrgId = imsOrgCode
-    const tenant = await schemaServiceClient.updateTenant(args.tenantId, data)
-    tenant
-      ? this.log(`Successfully updated the tenant with the id: ${data.tenantId}`)
-      : this.log(`Unable to update the tenant with the id: ${data.tenantId}`)
-    return tenant
-  }
+	async run() {
+		const { args } = this.parse(UpdateCommand);
+		const { schemaServiceClient, imsOrgCode } = await initSdk();
+		let data;
+		try {
+			data = JSON.parse(await readFile(args.file, 'utf8'));
+		} catch (error) {
+			this.error('Unable to update the tenant with the given configuration');
+		}
+		data.imsOrgId = imsOrgCode;
+		const tenant = await schemaServiceClient.updateTenant(args.tenantId, data);
+		tenant
+			? this.log(`Successfully updated the tenant with the id: ${data.tenantId}`)
+			: this.log(`Unable to update the tenant with the id: ${data.tenantId}`);
+		return tenant;
+	}
 }
 
-UpdateCommand.description = 'Update a tenant with the given config.'
+UpdateCommand.description = 'Update a tenant with the given config.';
 
-module.exports = UpdateCommand
+module.exports = UpdateCommand;

--- a/src/commands/commerce-gateway/tenant/update.js
+++ b/src/commands/commerce-gateway/tenant/update.js
@@ -11,12 +11,15 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command');
 const { readFile } = require('fs/promises');
-const { initSdk } = require('../../../helpers');
+const logger = require('../../../classes/logger');
+const { initSdk, initRequestId } = require('../../../helpers');
 
 class UpdateCommand extends Command {
 	static args = [{ name: 'tenantId' }, { name: 'file' }];
 
 	async run() {
+		await initRequestId();
+		logger.info(`RequestId: ${global.requestId}`);
 		const { args } = this.parse(UpdateCommand);
 		const { schemaServiceClient, imsOrgCode } = await initSdk();
 		let data;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -109,17 +109,8 @@ async function initRequestId() {
 	global.requestId = UUID.newUuid().toString();
 }
 
-/**
- * 
- * @returns Returns a requestId created for this particular command
- */
-async function getRequestId() {
-	return global.requestId;
-}
-
 module.exports = {
 	getCommerceAdminConfig,
 	initSdk,
 	initRequestId,
-	getRequestId,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,6 +17,7 @@ const libConsoleCLI = require('@adobe/aio-cli-lib-console');
 const { SchemaServiceClient } = require('./classes/SchemaServiceClient');
 const { getCliEnv } = require('@adobe/aio-lib-env');
 const logger = require('../src/classes/logger');
+const { UUID } = require('./classes/UUID');
 const aioConsoleLogger = require('@adobe/aio-lib-core-logging')(
 	'@adobe/aio-cli-plugin-commerce-admin',
 	{ provider: 'debug' },
@@ -101,7 +102,24 @@ async function initSdk() {
 	};
 }
 
+/**
+ * Generates a static global requestid for the lifecycle of this command request
+ */
+async function initRequestId() {
+	global.requestId = UUID.newUuid().toString();
+}
+
+/**
+ * 
+ * @returns Returns a requestId created for this particular command
+ */
+async function getRequestId() {
+	return global.requestId;
+}
+
 module.exports = {
 	getCommerceAdminConfig,
 	initSdk,
+	initRequestId,
+	getRequestId,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const libConsoleCLI = require('@adobe/aio-cli-lib-console');
 const { SchemaServiceClient } = require('./classes/SchemaServiceClient');
 const { getCliEnv } = require('@adobe/aio-lib-env');
+const logger = require('../src/classes/logger');
 const aioConsoleLogger = require('@adobe/aio-lib-core-logging')(
 	'@adobe/aio-cli-plugin-commerce-admin',
 	{ provider: 'debug' },
@@ -66,7 +67,7 @@ async function getAuthorizedOrganizations() {
 		this.imsOrgCode = selectedOrg.code;
 		return { imsOrgCode: this.imsOrgCode };
 	} else {
-		console.log(`Selecting your organization as: ${this.configOrgCode.name}`);
+		logger.info(`Selecting your organization as: ${this.configOrgCode.name}`);
 		return { imsOrgCode: this.configOrgCode.code };
 	}
 }
@@ -90,7 +91,7 @@ async function getLibConsoleCLI() {
  */
 async function initSdk() {
 	const { imsOrgCode } = await getAuthorizedOrganizations();
-	console.log('Initialized user login and the selected organization');
+	logger.info('Initialized user login and the selected organization');
 	const { baseUrl, accessToken, apiKey } = await getCommerceAdminConfig();
 	const schemaServiceClient = new SchemaServiceClient();
 	schemaServiceClient.init(baseUrl, accessToken, apiKey);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,88 +9,98 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const Config = require('@adobe/aio-lib-core-config')
-const { getToken, context } = require('@adobe/aio-lib-ims')
-const { CLI } = require('@adobe/aio-lib-ims/src/context')
-const fs = require('fs')
-const libConsoleCLI = require('@adobe/aio-cli-lib-console')
-const { SchemaServiceClient } = require('./classes/SchemaServiceClient')
-const { getCliEnv } = require('@adobe/aio-lib-env')
-const aioConsoleLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-commerce-admin', { provider: 'debug' })
+const Config = require('@adobe/aio-lib-core-config');
+const { getToken, context } = require('@adobe/aio-lib-ims');
+const { CLI } = require('@adobe/aio-lib-ims/src/context');
+const fs = require('fs');
+const libConsoleCLI = require('@adobe/aio-cli-lib-console');
+const { SchemaServiceClient } = require('./classes/SchemaServiceClient');
+const { getCliEnv } = require('@adobe/aio-lib-env');
+const aioConsoleLogger = require('@adobe/aio-lib-core-logging')(
+	'@adobe/aio-cli-plugin-commerce-admin',
+	{ provider: 'debug' },
+);
 const CONSOLE_CONFIG_KEYS = {
-  CONSOLE: 'console',
-  ORG: 'org'
-}
+	CONSOLE: 'console',
+	ORG: 'org',
+};
 const CONSOLE_API_KEYS = {
-  prod: 'aio-cli-console-auth',
-  stage: 'aio-cli-console-auth-stage'
-}
+	prod: 'aio-cli-console-auth',
+	stage: 'aio-cli-console-auth-stage',
+};
 
 /**
  * @returns {any} Returns a config object or null
  */
-async function getCommerceAdminConfig () {
-  const configFile = Config.get('aio-cli-plugin-commerce-admin')
-  try {
-    const data = JSON.parse((fs.readFileSync(configFile,
-      { encoding: 'utf8', flag: 'r' })))
-    return {
-      baseUrl: data.baseUrl || 'https://commerce.adobe.io',
-      accessToken: (await getLibConsoleCLI()).accessToken,
-      apiKey: data.apiKey
-    }
-  } catch (error) {
-    return null
-  }
+async function getCommerceAdminConfig() {
+	const configFile = Config.get('aio-cli-plugin-commerce-admin');
+	try {
+		const data = JSON.parse(fs.readFileSync(configFile, { encoding: 'utf8', flag: 'r' }));
+		return {
+			baseUrl: data.baseUrl || 'https://commerce.adobe.io',
+			accessToken: (await getLibConsoleCLI()).accessToken,
+			apiKey: data.apiKey,
+		};
+	} catch (error) {
+		return null;
+	}
 }
 
 /**
  * @returns {string} Returns organizations the user belongs to
  */
-async function getAuthorizedOrganizations () {
-  const { consoleCLI } = await getLibConsoleCLI()
-  aioConsoleLogger.debug('Get the selected organization')
-  const key = CONSOLE_CONFIG_KEYS.ORG
-  this.configOrgCode = Config.get(`${CONSOLE_CONFIG_KEYS.CONSOLE}.${key}`)
-  if (!this.configOrgCode) {
-    const organizations = await consoleCLI.getOrganizations()
-    const selectedOrg = await consoleCLI.promptForSelectOrganization(organizations)
-    aioConsoleLogger.debug('Set the console config')
-    Config.set(`${CONSOLE_CONFIG_KEYS.CONSOLE}.${key}`, { id: selectedOrg.id, code: selectedOrg.code, name: selectedOrg.name })
-    this.imsOrgCode = selectedOrg.code
-    return { imsOrgCode: this.imsOrgCode }
-  } else {
-    console.log(`Selecting your organization as: ${this.configOrgCode.name}`)
-    return { imsOrgCode: this.configOrgCode.code }
-  }
+async function getAuthorizedOrganizations() {
+	const { consoleCLI } = await getLibConsoleCLI();
+	aioConsoleLogger.debug('Get the selected organization');
+	const key = CONSOLE_CONFIG_KEYS.ORG;
+	this.configOrgCode = Config.get(`${CONSOLE_CONFIG_KEYS.CONSOLE}.${key}`);
+	if (!this.configOrgCode) {
+		const organizations = await consoleCLI.getOrganizations();
+		const selectedOrg = await consoleCLI.promptForSelectOrganization(organizations);
+		aioConsoleLogger.debug('Set the console config');
+		Config.set(`${CONSOLE_CONFIG_KEYS.CONSOLE}.${key}`, {
+			id: selectedOrg.id,
+			code: selectedOrg.code,
+			name: selectedOrg.name,
+		});
+		this.imsOrgCode = selectedOrg.code;
+		return { imsOrgCode: this.imsOrgCode };
+	} else {
+		console.log(`Selecting your organization as: ${this.configOrgCode.name}`);
+		return { imsOrgCode: this.configOrgCode.code };
+	}
 }
 /**
  * @private
  */
-async function getLibConsoleCLI () {
-  await context.setCli({ 'cli.bare-output': true }, false)
-  const clientEnv = getCliEnv()
-  this.accessToken = await getToken(CLI)
-  this.consoleCLI = await libConsoleCLI.init({ accessToken: this.accessToken, apiKey: CONSOLE_API_KEYS[clientEnv], env: clientEnv })
-  return { consoleCLI: this.consoleCLI, accessToken: this.accessToken }
+async function getLibConsoleCLI() {
+	await context.setCli({ 'cli.bare-output': true }, false);
+	const clientEnv = getCliEnv();
+	this.accessToken = await getToken(CLI);
+	this.consoleCLI = await libConsoleCLI.init({
+		accessToken: this.accessToken,
+		apiKey: CONSOLE_API_KEYS[clientEnv],
+		env: clientEnv,
+	});
+	return { consoleCLI: this.consoleCLI, accessToken: this.accessToken };
 }
 
 /**
  * @returns {any} Returns an object with properties ready for consumption
  */
-async function initSdk () {
-  const { imsOrgCode } = await getAuthorizedOrganizations()
-  console.log('Initialized user login and the selected organization')
-  const { baseUrl, accessToken, apiKey } = await getCommerceAdminConfig()
-  const schemaServiceClient = new SchemaServiceClient()
-  schemaServiceClient.init(baseUrl, accessToken, apiKey)
-  return {
-    schemaServiceClient: schemaServiceClient,
-    imsOrgCode: imsOrgCode
-  }
+async function initSdk() {
+	const { imsOrgCode } = await getAuthorizedOrganizations();
+	console.log('Initialized user login and the selected organization');
+	const { baseUrl, accessToken, apiKey } = await getCommerceAdminConfig();
+	const schemaServiceClient = new SchemaServiceClient();
+	schemaServiceClient.init(baseUrl, accessToken, apiKey);
+	return {
+		schemaServiceClient: schemaServiceClient,
+		imsOrgCode: imsOrgCode,
+	};
 }
 
 module.exports = {
-  getCommerceAdminConfig,
-  initSdk
-}
+	getCommerceAdminConfig,
+	initSdk,
+};

--- a/test/commands/PLUGINNAME/index.test.js
+++ b/test/commands/PLUGINNAME/index.test.js
@@ -10,21 +10,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const IndexCommand = require('../../../src/commands/PLUGINNAME')
+const IndexCommand = require('../../../src/commands/PLUGINNAME');
 
 test('exports', async () => {
-  expect(typeof IndexCommand).toEqual('function')
-})
+	expect(typeof IndexCommand).toEqual('function');
+});
 
 describe('command tests', () => {
-  let command
+	let command;
 
-  beforeEach(() => {
-    command = new IndexCommand([])
-  })
+	beforeEach(() => {
+		command = new IndexCommand([]);
+	});
 
-  test('run', async () => {
-    command.argv = []
-    await expect(command.run()).resolves.not.toThrowError()
-  })
-})
+	test('run', async () => {
+		command.argv = [];
+		await expect(command.run()).resolves.not.toThrowError();
+	});
+});

--- a/test/commands/commerce-gateway/tenant/create.test.js
+++ b/test/commands/commerce-gateway/tenant/create.test.js
@@ -10,54 +10,52 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const mockConsoleCLIInstance = {}
-jest.mock('@adobe/aio-lib-env')
-jest.mock('@adobe/aio-cli-lib-console')
-const orgs = [
-  { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }
-]
-const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }
+const mockConsoleCLIInstance = {};
+jest.mock('@adobe/aio-lib-env');
+jest.mock('@adobe/aio-cli-lib-console');
+const orgs = [{ id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }];
+const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
 /**
  *
  */
-function setDefaultMockConsoleCLI () {
-  mockConsoleCLIInstance.getToken = jest.fn().mockReturnValue('test_token')
-  mockConsoleCLIInstance.getCliEnv = jest.fn().mockReturnValue('prod')
-  mockConsoleCLIInstance.getOrganizations = jest.fn().mockResolvedValue(orgs)
-  mockConsoleCLIInstance.promptForSelectOrganization = jest.fn().mockResolvedValue(selectedOrg)
+function setDefaultMockConsoleCLI() {
+	mockConsoleCLIInstance.getToken = jest.fn().mockReturnValue('test_token');
+	mockConsoleCLIInstance.getCliEnv = jest.fn().mockReturnValue('prod');
+	mockConsoleCLIInstance.getOrganizations = jest.fn().mockResolvedValue(orgs);
+	mockConsoleCLIInstance.promptForSelectOrganization = jest.fn().mockResolvedValue(selectedOrg);
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
-  init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
-  cleanStdOut: jest.fn()
-}))
-jest.mock('@adobe/aio-lib-ims')
-const CreateCommand = require('../../../../src/commands/commerce-gateway/tenant/create')
-const { SchemaServiceClient } = require('../../../../src/classes/SchemaServiceClient')
-const mockCreateTenant = require('../../../data/sample_mesh.json')
+	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
+	cleanStdOut: jest.fn(),
+}));
+jest.mock('@adobe/aio-lib-ims');
+const CreateCommand = require('../../../../src/commands/commerce-gateway/tenant/create');
+const { SchemaServiceClient } = require('../../../../src/classes/SchemaServiceClient');
+const mockCreateTenant = require('../../../data/sample_mesh.json');
 
 describe('create command tests', () => {
-  beforeEach(() => {
-    setDefaultMockConsoleCLI()
-    const response = mockCreateTenant
-    jest.spyOn(SchemaServiceClient.prototype, 'createTenant').mockImplementation((data) => response)
-  })
+	beforeEach(() => {
+		setDefaultMockConsoleCLI();
+		const response = mockCreateTenant;
+		jest.spyOn(SchemaServiceClient.prototype, 'createTenant').mockImplementation(data => response);
+	});
 
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
 
-  test('create-tenant-missing-file', async () => {
-    expect.assertions(2)
-    const runResult = CreateCommand.run([])
-    await expect(runResult instanceof Promise).toBeTruthy()
-    await expect(runResult).rejects.toEqual(
-      new Error('Unable to create a tenant with the given configuration')
-    )
-  })
-  test('create-tenant-with-configuration', async () => {
-    expect.assertions(2)
-    const runResult = CreateCommand.run(['test/data/sample_mesh.json'])
-    await expect(runResult instanceof Promise).toBeTruthy()
-    await expect(runResult).resolves.toEqual(mockCreateTenant)
-  })
-})
+	test('create-tenant-missing-file', async () => {
+		expect.assertions(2);
+		const runResult = CreateCommand.run([]);
+		await expect(runResult instanceof Promise).toBeTruthy();
+		await expect(runResult).rejects.toEqual(
+			new Error('Unable to create a tenant with the given configuration'),
+		);
+	});
+	test('create-tenant-with-configuration', async () => {
+		expect.assertions(2);
+		const runResult = CreateCommand.run(['test/data/sample_mesh.json']);
+		await expect(runResult instanceof Promise).toBeTruthy();
+		await expect(runResult).resolves.toEqual(mockCreateTenant);
+	});
+});

--- a/test/commands/commerce-gateway/tenant/get.test.js
+++ b/test/commands/commerce-gateway/tenant/get.test.js
@@ -10,53 +10,55 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const mockConsoleCLIInstance = {}
-jest.mock('@adobe/aio-lib-env')
-jest.mock('@adobe/aio-cli-lib-console')
-const orgs = [
-  { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }
-]
-const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }
+const mockConsoleCLIInstance = {};
+jest.mock('@adobe/aio-lib-env');
+jest.mock('@adobe/aio-cli-lib-console');
+const orgs = [{ id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }];
+const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
 /**
  *
  */
-function setDefaultMockConsoleCLI () {
-  mockConsoleCLIInstance.getToken = jest.fn().mockReturnValue('test_token')
-  mockConsoleCLIInstance.getCliEnv = jest.fn().mockReturnValue('prod')
-  mockConsoleCLIInstance.getOrganizations = jest.fn().mockResolvedValue(orgs)
-  mockConsoleCLIInstance.promptForSelectOrganization = jest.fn().mockResolvedValue(selectedOrg)
+function setDefaultMockConsoleCLI() {
+	mockConsoleCLIInstance.getToken = jest.fn().mockReturnValue('test_token');
+	mockConsoleCLIInstance.getCliEnv = jest.fn().mockReturnValue('prod');
+	mockConsoleCLIInstance.getOrganizations = jest.fn().mockResolvedValue(orgs);
+	mockConsoleCLIInstance.promptForSelectOrganization = jest.fn().mockResolvedValue(selectedOrg);
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
-  init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
-  cleanStdOut: jest.fn()
-}))
-jest.mock('@adobe/aio-lib-ims')
-const GetCommand = require('../../../../src/commands/commerce-gateway/tenant/get')
-const { SchemaServiceClient } = require('../../../../src/classes/SchemaServiceClient')
-const mockGetTenant = require('../../../data/sample_mesh.json')
+	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
+	cleanStdOut: jest.fn(),
+}));
+jest.mock('@adobe/aio-lib-ims');
+const GetCommand = require('../../../../src/commands/commerce-gateway/tenant/get');
+const { SchemaServiceClient } = require('../../../../src/classes/SchemaServiceClient');
+const mockGetTenant = require('../../../data/sample_mesh.json');
 
 describe('get command tests', () => {
-  beforeEach(() => {
-    setDefaultMockConsoleCLI()
-  })
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
+	beforeEach(() => {
+		setDefaultMockConsoleCLI();
+	});
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
 
-  test('get-tenant-missing-tenantId', async () => {
-    jest.spyOn(SchemaServiceClient.prototype, 'getTenant').mockImplementation(() => { throw new Error('{"message":"There was an error fetching undefined"}') })
-    expect.assertions(2)
-    const runResult = GetCommand.run([])
-    await expect(runResult instanceof Promise).toBeTruthy()
-    await expect(runResult).rejects.toEqual(
-      new Error('{"message":"There was an error fetching undefined"}')
-    )
-  })
-  test('get-tenant-with-tenantId', async () => {
-    jest.spyOn(SchemaServiceClient.prototype, 'getTenant').mockImplementation((tenantId) => mockGetTenant)
-    expect.assertions(1)
-    const tenantId = 'sample_merchant'
-    const runResult = GetCommand.run([tenantId])
-    await expect(runResult).resolves.toEqual(mockGetTenant)
-  })
-})
+	test('get-tenant-missing-tenantId', async () => {
+		jest.spyOn(SchemaServiceClient.prototype, 'getTenant').mockImplementation(() => {
+			throw new Error('{"message":"There was an error fetching undefined"}');
+		});
+		expect.assertions(2);
+		const runResult = GetCommand.run([]);
+		await expect(runResult instanceof Promise).toBeTruthy();
+		await expect(runResult).rejects.toEqual(
+			new Error('{"message":"There was an error fetching undefined"}'),
+		);
+	});
+	test('get-tenant-with-tenantId', async () => {
+		jest
+			.spyOn(SchemaServiceClient.prototype, 'getTenant')
+			.mockImplementation(tenantId => mockGetTenant);
+		expect.assertions(1);
+		const tenantId = 'sample_merchant';
+		const runResult = GetCommand.run([tenantId]);
+		await expect(runResult).resolves.toEqual(mockGetTenant);
+	});
+});

--- a/test/commands/commerce-gateway/tenant/update.test.js
+++ b/test/commands/commerce-gateway/tenant/update.test.js
@@ -10,53 +10,51 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const mockConsoleCLIInstance = {}
-jest.mock('@adobe/aio-lib-env')
-const orgs = [
-  { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }
-]
-const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }
+const mockConsoleCLIInstance = {};
+jest.mock('@adobe/aio-lib-env');
+const orgs = [{ id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }];
+const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
 /**
  *
  */
-function setDefaultMockConsoleCLI () {
-  mockConsoleCLIInstance.getToken = jest.fn().mockReturnValue('test_token')
-  mockConsoleCLIInstance.getCliEnv = jest.fn().mockReturnValue('prod')
-  mockConsoleCLIInstance.getOrganizations = jest.fn().mockResolvedValue(orgs)
-  mockConsoleCLIInstance.promptForSelectOrganization = jest.fn().mockResolvedValue(selectedOrg)
+function setDefaultMockConsoleCLI() {
+	mockConsoleCLIInstance.getToken = jest.fn().mockReturnValue('test_token');
+	mockConsoleCLIInstance.getCliEnv = jest.fn().mockReturnValue('prod');
+	mockConsoleCLIInstance.getOrganizations = jest.fn().mockResolvedValue(orgs);
+	mockConsoleCLIInstance.promptForSelectOrganization = jest.fn().mockResolvedValue(selectedOrg);
 }
 jest.mock('@adobe/aio-cli-lib-console', () => ({
-  init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
-  cleanStdOut: jest.fn()
-}))
-jest.mock('@adobe/aio-lib-ims')
-const UpdateCommand = require('../../../../src/commands/commerce-gateway/tenant/update')
-const { SchemaServiceClient } = require('../../../../src/classes/SchemaServiceClient')
-const mockUpdateTenant = require('../../../data/sample_mesh.json')
+	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
+	cleanStdOut: jest.fn(),
+}));
+jest.mock('@adobe/aio-lib-ims');
+const UpdateCommand = require('../../../../src/commands/commerce-gateway/tenant/update');
+const { SchemaServiceClient } = require('../../../../src/classes/SchemaServiceClient');
+const mockUpdateTenant = require('../../../data/sample_mesh.json');
 
 describe('update command tests', () => {
-  beforeEach(() => {
-    setDefaultMockConsoleCLI()
-    const response = mockUpdateTenant
-    jest.spyOn(SchemaServiceClient.prototype, 'updateTenant').mockImplementation((data) => response)
-  })
+	beforeEach(() => {
+		setDefaultMockConsoleCLI();
+		const response = mockUpdateTenant;
+		jest.spyOn(SchemaServiceClient.prototype, 'updateTenant').mockImplementation(data => response);
+	});
 
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
 
-  test('update-tenant-missing-tenantId-file', async () => {
-    expect.assertions(2)
-    const runResult = UpdateCommand.run([])
-    await expect(runResult instanceof Promise).toBeTruthy()
-    await expect(runResult).rejects.toEqual(
-      new Error('Unable to update the tenant with the given configuration')
-    )
-  })
-  test('update-tenant-with-configuration', async () => {
-    expect.assertions(2)
-    const runResult = UpdateCommand.run(['sample_merchant', 'test/data/sample_mesh.json'])
-    await expect(runResult instanceof Promise).toBeTruthy()
-    await expect(runResult).resolves.toEqual(mockUpdateTenant)
-  })
-})
+	test('update-tenant-missing-tenantId-file', async () => {
+		expect.assertions(2);
+		const runResult = UpdateCommand.run([]);
+		await expect(runResult instanceof Promise).toBeTruthy();
+		await expect(runResult).rejects.toEqual(
+			new Error('Unable to update the tenant with the given configuration'),
+		);
+	});
+	test('update-tenant-with-configuration', async () => {
+		expect.assertions(2);
+		const runResult = UpdateCommand.run(['sample_merchant', 'test/data/sample_mesh.json']);
+		await expect(runResult instanceof Promise).toBeTruthy();
+		await expect(runResult).resolves.toEqual(mockUpdateTenant);
+	});
+});


### PR DESCRIPTION
Adding requestId tracing in the cli plugin

## Description

Adding a requestid from the cli that persists through to the SMS application.
Added linting rules so that the code formatting rules are enforced

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Helps troubleshoot issues when viewing logs

## How Has This Been Tested?

Ran the CLI and then viewed SMS to see if the requestid persisted through the application

## Screenshots (if appropriate):

![Screen Shot 2022-04-05 at 6 44 59 PM](https://user-images.githubusercontent.com/100383619/161868955-f08519c1-a68d-4a93-abb0-61c30e2d6f7c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
