### PR TITLE
CEXT-333: Update CLI to use baked-in  API Key and SMS url if config json is absent

### DIFF
--- a/src/commands/commerce-gateway/tenant/__tests__/create.test.js
+++ b/src/commands/commerce-gateway/tenant/__tests__/create.test.js
@@ -54,7 +54,7 @@ describe('create command tests', () => {
 	});
 	test('create-tenant-with-configuration', async () => {
 		expect.assertions(2);
-		const runResult = CreateCommand.run(['test/data/sample_mesh.json']);
+		const runResult = CreateCommand.run(['src/commands/__fixtures__/sample_mesh.json']);
 		await expect(runResult instanceof Promise).toBeTruthy();
 		await expect(runResult).resolves.toEqual(mockCreateTenant);
 	});

--- a/src/commands/commerce-gateway/tenant/__tests__/update.test.js
+++ b/src/commands/commerce-gateway/tenant/__tests__/update.test.js
@@ -53,7 +53,10 @@ describe('update command tests', () => {
 	});
 	test('update-tenant-with-configuration', async () => {
 		expect.assertions(2);
-		const runResult = UpdateCommand.run(['sample_merchant', 'test/data/sample_mesh.json']);
+		const runResult = UpdateCommand.run([
+			'sample_merchant',
+			'src/commands/__fixtures__/sample_mesh.json',
+		]);
 		await expect(runResult instanceof Promise).toBeTruthy();
 		await expect(runResult).resolves.toEqual(mockUpdateTenant);
 	});

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -27,8 +27,7 @@ class CreateCommand extends Command {
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 		} catch (error) {
-			logger.error(error);
-			logger.error('Unable to create a tenant with the given configuration');
+			this.error('Unable to create a tenant with the given configuration');
 		}
 		data.imsOrgId = imsOrgCode;
 		const tenant = await schemaServiceClient.createTenant(data);

--- a/src/commands/commerce-gateway/tenant/create.js
+++ b/src/commands/commerce-gateway/tenant/create.js
@@ -28,7 +28,7 @@ class CreateCommand extends Command {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 		} catch (error) {
 			logger.error(error);
-			this.error('Unable to create a tenant with the given configuration');
+			logger.error('Unable to create a tenant with the given configuration');
 		}
 		data.imsOrgId = imsOrgCode;
 		const tenant = await schemaServiceClient.createTenant(data);

--- a/src/commands/commerce-gateway/tenant/update.js
+++ b/src/commands/commerce-gateway/tenant/update.js
@@ -27,13 +27,13 @@ class UpdateCommand extends Command {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 		} catch (error) {
 			logger.error(error);
-			this.error('Unable to update the tenant with the given configuration');
+			logger.error('Unable to update the tenant with the given configuration');
 		}
 		data.imsOrgId = imsOrgCode;
 		const tenant = await schemaServiceClient.updateTenant(args.tenantId, data);
 		tenant
-			? this.log(`Successfully updated the tenant with the id: ${data.tenantId}`)
-			: this.log(`Unable to update the tenant with the id: ${data.tenantId}`);
+			? logger.info(`Successfully updated the tenant with the id: ${args.tenantId}`)
+			: logger.info(`Unable to update the tenant with the id: ${args.tenantId}`);
 		return tenant;
 	}
 }

--- a/src/commands/commerce-gateway/tenant/update.js
+++ b/src/commands/commerce-gateway/tenant/update.js
@@ -27,7 +27,7 @@ class UpdateCommand extends Command {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 		} catch (error) {
 			logger.error(error);
-			logger.error('Unable to update the tenant with the given configuration');
+			this.error('Unable to update the tenant with the given configuration');
 		}
 		data.imsOrgId = imsOrgCode;
 		const tenant = await schemaServiceClient.updateTenant(args.tenantId, data);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -36,15 +36,27 @@ const CONSOLE_API_KEYS = {
  */
 async function getCommerceAdminConfig() {
 	const configFile = Config.get('aio-cli-plugin-commerce-admin');
-	try {
-		const data = JSON.parse(fs.readFileSync(configFile, { encoding: 'utf8', flag: 'r' }));
+
+	if (!configFile) {
 		return {
-			baseUrl: data.baseUrl || 'https://commerce.adobe.io',
+			baseUrl: 'https://graph.adobe.io',
 			accessToken: (await getLibConsoleCLI()).accessToken,
-			apiKey: data.apiKey,
+			apiKey: 'graphql-onboarding-io',
 		};
-	} catch (error) {
-		return null;
+	} else {
+		try {
+			const data = JSON.parse(fs.readFileSync(configFile, { encoding: 'utf8', flag: 'r' }));
+			return {
+				baseUrl: data.baseUrl || 'https://graph.adobe.io',
+				accessToken: (await getLibConsoleCLI()).accessToken,
+				apiKey: data.apiKey || 'graphql-onboarding-io',
+			};
+		} catch (error) {
+			logger.error(
+				'Please run aio config set command to set the correct path to config json with valid baseUrl and apiKey',
+			);
+			throw new Error();
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Update CLI to bake-in a Prod API Key and Prod SMS URL. This PR should just be another inlet for users to interact with the mesh if they don't have an API key. We should still be accepting API key and an SMS URL from the config file and if those details are not provided, baked-in API Key and URL should be used

## Related Issue
none

## Motivation and Context

Update CLI to bake-in a Prod API Key and Prod SMS URL. This PR should just be another inlet for users to interact with the mesh if they don't have an API key. We should still be accepting API key and an SMS URL from the config file and if those details are not provided, baked-in API Key and URL should be used

## How Has This Been Tested?

### Steps to Reproduce
Once the branch is pulled down, run the below command to link plugin into the CLI for development/testing
 `aio plugins:link commerce-gateway/tenant`

### TEST PLAN
**Use Case 1:**
Verify that if the config.json has both **baseUrl** and **apiKey** available and if the user has run the command to set the path to the config.json like below, then those values takes precedence over the hard coded config values ; provided the user is an authenticated user of the appropriate IMS env.
`aio config:set aio-cli-plugin-commerce-admin <path to config.json>`

**Use Case 2:**
Verify that if config.json is not available and the user hasn't set the path as a pre requisite step, then the baked-in prod url and apiKey will be automatically used ; provided the user is an authenticated prod IMS user and is part of an organization within prod dev console

**Use Case 3: **
If the config.json is empty or the user has set an incorrect path to config.json, verify that the user gets the message to set the path with the right data

**Use Case 4:**
If the config.json is available with either **baseUrl** or **apiKey** and the path to it is set in the ~/.config/aio ; Verify that the GET/CREATE/UPDATE commands would fail with this below error, if those partial config.json values doesn't correspond to prod values
    `Error: {"error":{"code":"Forbidden","message":"Client ID is invalid","details":{"error_code":"403003"}}}`


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
