### PR TITLE
Adding prod api key for CLI

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -38,7 +38,7 @@ async function getCommerceAdminConfig() {
 		return {
 			baseUrl: 'https://developers.adobe.io/console',
 			accessToken: (await getLibConsoleCLI()).accessToken,
-			apiKey: 'adobe-api-manager-sms-stage',
+			apiKey: 'adobe-graph-prod',
 		};
 	} else {
 		try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have created a new API Key that has access to both Prod Dev Console and Prod SMS. This API Key will be used by customers who don't have a config file of their own.

Here is the API Key URL: https://admin.adobe.io/consumer/org/872619/apps/291007

## Related Issue

None

## Motivation and Context

None

## How Has This Been Tested?

Not tested since SMS and Dev Console Mesh API are not deployed on prod

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
