### PR TITLE
Allign local secrets with worker by JSON-parsing string values.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.6.3",
+	"version": "5.6.4-beta.1",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/__tests__/readSecretsFile.test.js
+++ b/src/commands/api-mesh/__tests__/readSecretsFile.test.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { readSecretsFile } = require('../../../serverUtils');
+const { loadMeshSecrets } = require('../../../secrets');
+
+describe('readSecretsFile', () => {
+	let tmp;
+	let prevCwd;
+
+	afterEach(() => {
+		if (prevCwd !== undefined) {
+			process.chdir(prevCwd);
+			prevCwd = undefined;
+		}
+		if (tmp) {
+			fs.rmSync(tmp, { recursive: true, force: true });
+			tmp = undefined;
+		}
+	});
+
+	test('parses JSON object strings in secrets.yaml like the tenant worker', () => {
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'readSecretsFile-test-'));
+		const meshDir = path.join(tmp, '.mesh');
+		fs.mkdirSync(meshDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(meshDir, 'secrets.yaml'),
+			`TOKEN: '{"COMMERCE": "dummy-value"}'\nPLAIN: not-json\n`,
+			'utf8',
+		);
+		prevCwd = process.cwd();
+		process.chdir(tmp);
+
+		const secrets = readSecretsFile('.mesh');
+
+		expect(secrets.TOKEN).toEqual({ COMMERCE: 'dummy-value' });
+		expect(secrets.PLAIN).toBe('not-json');
+
+		const mockLogger = { error: jest.fn() };
+		const asWorkerSees = loadMeshSecrets(mockLogger, JSON.stringify(secrets));
+		expect(asWorkerSees.TOKEN.COMMERCE).toBe('dummy-value');
+		expect(asWorkerSees.PLAIN).toBe('not-json');
+		expect(mockLogger.error).not.toHaveBeenCalled();
+	});
+});

--- a/src/serverUtils.js
+++ b/src/serverUtils.js
@@ -317,6 +317,31 @@ function ccDirectivesToString(directives) {
 }
 
 /**
+ * Match production tenant-worker behavior: each bound secret value is JSON.parsed.
+ * YAML often leaves JSON blobs as strings; without this step, values like TOKEN: '{"COMMERCE": "dummy-value"}' stay broken locally.
+ *
+ * @param {Record<string, unknown>} secrets Parsed secrets object
+ * @returns {Record<string, unknown>}
+ */
+function normalizeSecretsEnvValues(secrets) {
+	if (!secrets || typeof secrets !== 'object' || Array.isArray(secrets)) {
+		return secrets;
+	}
+	return Object.fromEntries(
+		Object.entries(secrets).map(([key, value]) => {
+			if (typeof value === 'string') {
+				try {
+					return [key, JSON.parse(value)];
+				} catch {
+					return [key, value];
+				}
+			}
+			return [key, value];
+		}),
+	);
+}
+
+/**
  * Returns secrets content from artifacts
  * @param meshPath
  * @returns
@@ -326,7 +351,8 @@ function readSecretsFile(meshPath) {
 	try {
 		const filePath = path.resolve(process.cwd(), `${meshPath}`, 'secrets.yaml');
 		if (fs.existsSync(filePath)) {
-			secrets = YAML.parse(fs.readFileSync(filePath, 'utf8'));
+			const parsed = YAML.parse(fs.readFileSync(filePath, 'utf8'));
+			secrets = normalizeSecretsEnvValues(parsed || {});
 		}
 	} catch (error) {
 		logger.error('Unexpected error: unable to locate secrets file in mesh artifacts.');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Local `aio api-mesh run` loads secrets from `.mesh/secrets.yaml`, stringifies them into the SECRETS env var, and the dev server parses that JSON. 
String values stayed strings, so paths like `context.secrets.TOKEN.COMMERCE` failed when TOKEN was authored as a JSON blob in YAML (e.g. `TOKEN: '{"COMMERCE": "dummy-value"}'`).

On the deployed tenant worker, each SECRETS__* binding is passed through JSON.parse when possible, so the same YAML shape becomes a nested object at runtime and those paths work.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-6008

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

* Validated by making a local link of CLI and confirm that JSON in YAML is working same as tenant worker.
* In secrets.yaml => `TOKEN: '{"COMMERCE": "dummy-value"}'`
* In mesh.json => `"secret3": "{context.secrets.TOKEN.COMMERCE}"`
* When query mesh secret3 resolves in: `"secret3": "dummy-value"`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
