### PR TITLE
Fix/mesh peer deps

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const config = {
 	testEnvironment: 'node',
 	reporters: ['default', 'jest-junit'],
 	setupFilesAfterEnv: ['./jest.setup.js'],
-	testPathIgnorePatterns: ['/node_modules/', '\\.integration\\.test\\.js$'],
+	testPathIgnorePatterns: ['/node_modules/'],
 };
 
 module.exports = config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const config = {
 	testEnvironment: 'node',
 	reporters: ['default', 'jest-junit'],
 	setupFilesAfterEnv: ['./jest.setup.js'],
+	testPathIgnorePatterns: ['/node_modules/', '\\.integration\\.test\\.js$'],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.7.0",
+	"version": "5.7.1-beta.0",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"postpack": "rm -f oclif.manifest.json",
 		"test": "jest",
 		"test:ci": "jest --ci",
+		"test:integration": "jest --testPathPattern=\\.integration\\.test\\.js",
 		"unit-tests": "jest --ci",
 		"version": "oclif-dev readme && git add README.md"
 	},

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@escape.tech/graphql-armor": "3.2.0",
 		"@graphql-mesh/cli": "0.82.30",
 		"@graphql-mesh/graphql": "0.34.13",
-		"@graphql-mesh/http": "^0.96.9",
+		"@graphql-mesh/http": "0.3.26",
 		"@graphql-mesh/json-schema": "0.35.38",
 		"@graphql-mesh/openapi": "0.33.39",
 		"@graphql-mesh/plugin-http-details-extensions": "^0.103.4",
@@ -129,7 +129,8 @@
 		"stdout-stderr": "^0.1.9"
 	},
 	"overrides": {
-		"plain-crypto-js": "./_EXCLUDE_UNSAFE_DEPENDENCIES_/plain-crypto-js"
+		"plain-crypto-js": "./_EXCLUDE_UNSAFE_DEPENDENCIES_/plain-crypto-js",
+		"@graphql-mesh/utils": "0.43.20"
 	},
 	"engines": {
 		"node": "^16.13 || >=18.0.0",

--- a/src/commands/api-mesh/__tests__/init.integration.test.js
+++ b/src/commands/api-mesh/__tests__/init.integration.test.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+jest.setTimeout(120000);
+
+describe('init template dependency resolution', () => {
+	let tmpDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-init-'));
+		fs.copyFileSync(
+			path.resolve(__dirname, '../../../templates/package.json'),
+			path.join(tmpDir, 'package.json'),
+		);
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('template package.json resolves without ERESOLVE errors', () => {
+		let stderr = '';
+		try {
+			execSync('npm install --dry-run --json', {
+				cwd: tmpDir,
+				encoding: 'utf8',
+				stdio: ['pipe', 'pipe', 'pipe'],
+			});
+		} catch (error) {
+			stderr = error.stderr || '';
+			if (stderr.includes('ERESOLVE')) {
+				throw new Error(`Template package.json has dependency conflicts:\n${stderr}`);
+			}
+			throw error;
+		}
+		expect(stderr).not.toContain('ERESOLVE');
+	});
+});

--- a/src/commands/api-mesh/__tests__/init.integration.test.js
+++ b/src/commands/api-mesh/__tests__/init.integration.test.js
@@ -33,7 +33,6 @@ describe('init template dependency resolution', () => {
 	});
 
 	test('template package.json resolves without ERESOLVE errors', () => {
-		let stderr = '';
 		try {
 			execSync('npm install --dry-run --json', {
 				cwd: tmpDir,
@@ -41,12 +40,11 @@ describe('init template dependency resolution', () => {
 				stdio: ['pipe', 'pipe', 'pipe'],
 			});
 		} catch (error) {
-			stderr = error.stderr || '';
+			const stderr = error.stderr || '';
 			if (stderr.includes('ERESOLVE')) {
 				throw new Error(`Template package.json has dependency conflicts:\n${stderr}`);
 			}
 			throw error;
 		}
-		expect(stderr).not.toContain('ERESOLVE');
 	});
 });

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -24,7 +24,6 @@
 		"@graphql-mesh/transform-type-merging": "0.5.20",
 		"@graphql-mesh/types": "0.91.12",
 		"@graphql-mesh/soap": "0.14.25",
-		"@graphql-mesh/http": "0.3.26",
 		"graphql": "^16.6.0",
 		"@adobe/plugin-hooks": "0.4.0",
 		"@adobe/plugin-on-fetch": "0.1.1",
@@ -35,15 +34,15 @@
 		"fastify": "^4.10.2",
 		"graphql-yoga": "3.1.1"
 	},
+	"overrides": {
+		"@graphql-mesh/utils": "0.43.20"
+	},
 	"engines": {
 		"node": ">=18.0.0"
 	},
 	"keywords": [
 		"api-mesh"
 	],
-	"overrides": {
-		"@graphql-mesh/utils": "0.43.20"
-	},
 	"license": "Apache-2.0",
 	"scripts": {
 		"start": "nodemon --watch .env -e js,json,yaml node_modules/.bin/aio api-mesh run",

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -24,7 +24,7 @@
 		"@graphql-mesh/transform-type-merging": "0.5.20",
 		"@graphql-mesh/types": "0.91.12",
 		"@graphql-mesh/soap": "0.14.25",
-		"@graphql-mesh/http": "0.3.26",
+		"@graphql-mesh/http": "^0.96.9",
 		"graphql": "^16.6.0",
 		"@adobe/plugin-hooks": "0.4.0",
 		"@adobe/plugin-on-fetch": "0.1.1",

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -24,7 +24,7 @@
 		"@graphql-mesh/transform-type-merging": "0.5.20",
 		"@graphql-mesh/types": "0.91.12",
 		"@graphql-mesh/soap": "0.14.25",
-		"@graphql-mesh/http": "^0.96.9",
+		"@graphql-mesh/http": "0.3.26",
 		"graphql": "^16.6.0",
 		"@adobe/plugin-hooks": "0.4.0",
 		"@adobe/plugin-on-fetch": "0.1.1",

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -24,7 +24,7 @@
 		"@graphql-mesh/transform-type-merging": "0.5.20",
 		"@graphql-mesh/types": "0.91.12",
 		"@graphql-mesh/soap": "0.14.25",
-		"@graphql-mesh/http": "^0.96.9",
+		"@graphql-mesh/http": "0.3.26",
 		"graphql": "^16.6.0",
 		"@adobe/plugin-hooks": "0.4.0",
 		"@adobe/plugin-on-fetch": "0.1.1",
@@ -41,6 +41,9 @@
 	"keywords": [
 		"api-mesh"
 	],
+	"overrides": {
+		"@graphql-mesh/utils": "0.43.20"
+	},
 	"license": "Apache-2.0",
 	"scripts": {
 		"start": "nodemon --watch .env -e js,json,yaml node_modules/.bin/aio api-mesh run",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
aio api-mesh init fails with npm error ERESOLVE when user selects npm as package manager.: https://jira.corp.adobe.com/browse/CEXT-4473

### Cause
Two independent dependency conflicts in the init template's `package.json`:

**Conflict 1 — utils/types:** The template depends on `@graphql-mesh/utils` transitively (via graphql → store → utils). npm resolves `utils@^0.43.20` to the latest matching version from the registry — `0.43.23` — which tightened its peer dependency on `@graphql-mesh/types` from `^0.91.12` to `^0.91.15`. The root project pins `types@0.91.12`, so npm's strict peer resolution rejects the tree.
```
root: @graphql-mesh/types@0.91.12 (pinned)
└── @graphql-mesh/graphql@0.34.13
└── needs @graphql-mesh/utils@^0.43.20
└── npm picks utils@0.43.23 (latest matching from registry)
└── needs @graphql-mesh/types@^0.91.15  ← CONFLICT (root has 0.91.12)
```
Checked registry - 
- utils@0.43.20 → requires types@^0.91.12 ✓ → https://registry.npmjs.org/@graphql-mesh/utils/0.43.20
- utils@0.43.23 → requires types@^0.91.15 ✗ → https://registry.npmjs.org/@graphql-mesh/utils/0.43.23

**Conflict 2 — cross-helpers (http):** `@graphql-mesh/http@^0.96.9` belongs to a newer mesh generation and pulls `cross-helpers@^0.4.x`, while the rest of the stack (`runtime@0.46.21`) requires `cross-helpers@^0.3.4`.

```
@graphql-mesh/http@0.96.14
└── needs @graphql-mesh/cross-helpers@^0.4.x

@graphql-mesh/runtime@0.46.21
└── needs @graphql-mesh/cross-helpers@^0.3.4  ← CONFLICT
```
Same reproducilbe on diff machine locally 
```
Ajaz-PC adobe-mesh-projects % aio api-mesh:init standard-mesh
? Do you want to create the workspace in /Users/umarajaz/adobe-mesh-projects Yes

? Do you want to initiate git in your workspace? No
? Select a package manager npm
? The directory is not empty. Do you want to create a sub directory with project
 name Yes
Creating workspace in /Users/umarajaz/adobe-mesh-projects/standard-mesh
Installing dependencies
    Error: npm install exection failed
Ajaz-PC adobe-mesh-projects % cd ~/adobe-mesh-projects/standard-mesh
Ajaz-PC standard-mesh % npm install --all
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: [standard-mesh@0.0.1](mailto:standard-mesh@0.0.1)
npm error Found: @graphql-mesh/types@0.91.12
npm error node_modules/@graphql-mesh/types
npm error   @graphql-mesh/types@"0.91.12" from the root project
npm error   peer @graphql-mesh/types@"^0.91.12" from @graphql-mesh/graphql@0.34.13
npm error   node_modules/@graphql-mesh/graphql
npm error     @graphql-mesh/graphql@"0.34.13" from the root project
npm error   1 more (@graphql-mesh/store)
npm error
npm error Could not resolve dependency:
npm error peer @graphql-mesh/types@"^0.91.15" from @graphql-mesh/utils@0.43.23
npm error node_modules/@graphql-mesh/utils
npm error   peer @graphql-mesh/utils@"^0.43.20" from @graphql-mesh/graphql@0.34.13
npm error   node_modules/@graphql-mesh/graphql
npm error     @graphql-mesh/graphql@"0.34.13" from the root project
npm error   peer @graphql-mesh/utils@"^0.43.20" from @graphql-mesh/store@0.9.20
npm error   node_modules/@graphql-mesh/store
npm error     peer @graphql-mesh/store@"^0.9.20" from @graphql-mesh/graphql@0.34.13
npm error     node_modules/@graphql-mesh/graphql
npm error       @graphql-mesh/graphql@"0.34.13" from the root project
npm error     1 more (@graphql-mesh/types)
npm error
npm error Fix the upstream dependency conflict, or retry this command with --force or --legacy-peer-deps to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/ajaz/.npm/_logs/2026-06-18T10_42_50_085Z-eresolve-report.txt
npm error A complete log of this run can be found in: /Users/ajaz/.npm/_logs/2026-06-18T10_42_50_085Z-debug-0.log


Ajaz-PC standard-mesh % aio plugins
@adobe/aio-cli-plugin-api-mesh 5.7.0

Ajaz-PC standard-mesh % node --version && npm --version
v26.3.0
11.16.0
```
### Why only `init` fails 
The root CLI plugin's `package-lock.json` locks `utils` to `0.43.20` (generated when that was the latest), so `npm install` on the plugin itself respects the lockfile and never hits the conflict. The init template has **no lockfile** — every `aio api-mesh:init` does a fresh `npm install` which resolves from the registry, picking `utils@0.43.23`.

### Why yarn users don't see this
yarn allows multiple versions of a peer dependency to coexist. 


### Fix :
1. **Downgraded `@graphql-mesh/http`** from `^0.96.9` to `0.3.26` — cannot remove from root because `@graphql-mesh/cli@0.82.30` uses it internally for its `mesh serve` command (`cli/commands/serve/serve.js` imports `createMeshHTTPHandler`). Pinning to `0.3.26` aligns with the version cli@0.82.30 already depends on.

Checked `@graphql-mesh/http` is unused:
<img width="804" height="59" alt="image" src="https://github.com/user-attachments/assets/8931848d-6222-4b82-817e-f8547d3f6e33" />

server.js line 1 (imports runtime, not http):
https://github.com/adobe/aio-cli-plugin-api-mesh/blob/main/src/server.js#L1
server.js line 6 (imports graphql-yoga):
https://github.com/adobe/aio-cli-plugin-api-mesh/blob/main/src/server.js#L6
serverUtils.js (no http import):
https://github.com/adobe/aio-cli-plugin-api-mesh/blob/main/src/serverUtils.js
Template package.json line 27 (only place http appears):
https://github.com/adobe/aio-cli-plugin-api-mesh/blob/main/src/templates/package.json#L27

Tracing why http module history in the package:
`@graphql-mesh/http@^0.96.9` was introduced in PR #89[Closed] (Oct 2023, CEXT-1646 "Run Command - Local Dev Server") — it was likely tried as the HTTP transport, then replaced with graphql-yoga, but the dependency was never cleaned up from the template.

2. **Added `@graphql-mesh/utils: "0.43.20"` to overrides** — defensive fix so the root is also protected if `package-lock.json` is ever regenerated.

### Impact: 
none. 
None. The local dev server is unaffected — it never used `@graphql-mesh/http`. Root retains http at `0.3.26` for cli's internal use.

@graphql-mesh/http is listed in the template but never imported — the local dev server (aio api-mesh run) uses graphql-yoga + fastify directly via @graphql-mesh/runtime. 
Confirmed by grep: zero imports of @graphql-mesh/http in CLI source code.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
